### PR TITLE
feat: Allow guest access to backstage.

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -49,7 +49,7 @@ const app = createApp({
   apis,
   components: {
     SignInPage: props => (
-      <SignInPage {...props} auto provider={githubProvider} />
+      <SignInPage {...props} auto providers={['guest', githubProvider]} />
     ),
   },
   bindRoutes({ bind }) {


### PR DESCRIPTION
If the user is not in the `openedx` org, the login fails because the
user is not in the auth backend database.
