### PR TITLE
feat: add LTI Component

### DIFF
--- a/catalog-extra/lti/catalog-info.yaml
+++ b/catalog-extra/lti/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: LTI
+  description: >
+    Learning Tools Interoperability (LTI) support in Open edX. This Component is
+    intended to be broader and more abstract than the xblock-lti-consumer, and
+    is intended to capture the overall way we think about LTI as a platform
+    level service (including things like strategy, certification, etc.)
+
+    The ownership for this is a stub value.
+spec:
+  type: other
+  owner: user:ormsbee
+  lifecycle: production


### PR DESCRIPTION
Add a new LTI Component to Backstage, and establish the pattern for how we add components that don't map directly 1:1 with a repo.