### PR TITLE
feat!: Switch to github app based auth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,54 +9,20 @@ To start the app, run:
 - Get Node 16: `nvm install 16`
     - This is not necessary if you already have Node 16 installed.
 - Install Yarn: `npm install --global yarn`
+- Ask a maintainer for access to the dev/prod credentials.
+    - If you need to create/re-create the creds there's a how-to in the docs repo.
 
-### Setup Github Tokens
 
-You'll need both a github personal access token and a github app to fully run
-this version of backstage.  By the end of this section, you should have the following
-three environment variables set in your shell:
-
-- `GITHUB_TOKEN`
-- `AUTH_GITHUB_CLIENT_SECRET`
-- `AUTH_GITHUB_CLIENT_ID`
-
-#### Personal Token
-
-You will need a new GitHub Personal Access Token with the following permissions:
-- `repo`
-- `user:email`
-- `read:org`
-- `read:discussion`
-
-See https://backstage.io/docs/integrations/github/locations for why you need each of those.
-
-1. Go to: https://github.com/settings/tokens
-2. Create a new token with those scopes.
-3. Save this token for use when you're developing.
-
-#### GitHub App
-
-1. Go to https://github.com/settings/apps
-2. Create your own github app with the following settings:
-
-    - Name: "\<your github handle\> Backstage Local"
-    - Homepage URL: "http://localhost:3000"
-    - Callback URL: "http://localhost:7007/api/auth/github"
-    - Disable Webhook
-
-3. Create the App
-
-4. Then from the created app, `Generate a new client secret`
-
-5. Save the client ID and client secret for use when you're developing.
 ## Everytime You Develop
 
 1. Export the various auth settings you need to run backstage locally.
     ```
-    export AUTH_GITHUB_CLIENT_SECRET=<new secret>
+    export AUTH_GITHUB_CLIENT_APP_ID=...
     export AUTH_GITHUB_CLIENT_ID=Iv1....
-    export GITHUB_TOKEN=ghp_...
+    export AUTH_GITHUB_CLIENT_SECRET=<new secret>
+    export AUTH_GITHUB_CLIENT_PRIVATE_KEY=...
     ```
+
 2. Start up the dev server
     ```sh
     yarn install

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -40,9 +40,16 @@ backend:
 integrations:
   github:
     - host: github.com
-      # This is a Personal Access Token or PAT from GitHub. You can find out how to generate this token, and more information
-      # about setting up the GitHub integration here: https://backstage.io/docs/getting-started/configuration#setting-up-a-github-integration
-      token: ${GITHUB_TOKEN}
+      # Backstage docs for how to generate these: https://backstage.io/docs/integrations/github/github-apps
+      # We also have more specific docs in `docs/source/how-tos/create-github-credentials.rst`
+      apps:
+        - appId: ${AUTH_GITHUB_APP_ID}
+          clientId: ${AUTH_GITHUB_CLIENT_ID}
+          clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+          privateKey: ${AUTH_GITHUB_PRIVATE_KEY}
+          # Webhooks are disabled because we don't make use of them but backstage still needs a non-empty string.
+          # If we ever start using this, we should pull this value from an environment variable like the others.
+          webhookSecret: not-a-secret
 
 proxy:
   '/test':

--- a/docs/source/how-tos/create-github-credentials.rst
+++ b/docs/source/how-tos/create-github-credentials.rst
@@ -1,0 +1,60 @@
+How to Create GitHub Credentials
+################################
+
+This how-to will walk you through the process of creating a github app in the
+right org and get all the credentials you need to be able to run the app.  The
+process is the same for development or production.
+
+You can look at the relevant backstage docs here: https://backstage.io/docs/integrations/github/github-apps
+
+1. In the org you want to connect to, make a new github app.
+
+   eg. In ``openedx`` go to
+   https://github.com/organizations/openedx/settings/apps and hit the
+   :guilabel:`New GitHub App` button.
+
+2. Fill out the form as follows:
+
+   * GitHub App name: Give your installation a unique name. eg. ``Backstage
+     [Local/Production] Open edX``
+
+   * Homepage URL: The homepage for the UI. eg.
+     ``https://backstage.openedx.org`` or ``https://localhost:3000``
+
+   * Callback URL: The callback url for auth purposes.  eg.
+     ``https://backstage.openedx.org/api/auth/github/handler/frame`` or
+     ``http://localhost:7007/api/auth/github``
+
+   * Webhook: Disable the webhook capability by unchecking the
+     :guilabel:`Active` checkbox.
+
+   * Repository Permissions (More details about why in the backstage docs linked
+     above.)
+
+      * ``Contents``: ``Read-only``
+
+      * ``Members``: ``Read-only``
+
+3. Click :guilabel:`Create GitHub App`
+
+4. Click :guilabel:`Create a new client secret` and save the generated secret.
+
+5. Click :guilabel:`Generate a private key` and save the generated key.
+
+6. Go to :guilabel:`Install App` and install the newly created app on your org.
+
+
+Once you've gone through these steps you should have everything you need to
+start up the app.  See the readme for how to pass these credentials to backstage
+at startup.
+
+For convenience, consider saving the follwing information in one file in your
+password manager:
+
+* App ID: The numeric ID of your app.
+
+* Client ID: Starts with ``Iv1``
+
+* Client Secret: That you generated above.
+
+* privateKey: The contents of the private key file.


### PR DESCRIPTION
Docs we followed: https://backstage.io/docs/integrations/github/github-apps

Previously we were using a github app for user login but a github
personal access token for talking to github and reading data for the
org.  This worked but very quickly ran into rate-limiting issues.
Switch the backend integration to also use the same github app to get a
higher rate limit.

BREAKING CHANGE: 2 new settings will need to be available in the
environment where backstage is running.  `AUTH_GITHUB_APP_ID` and
`AUTH_GITHUB_PRIVATE_KEY`.  Be sure to add those before deploying this
version of the app.

You can also remove the `GITHUB_TOKEN` variable as it is no longer used.
