### PR TITLE
docs!: Update deployment docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ authenticated.
 yarn install
 yarn tsc
 yarn build
-docker image build . -f packages/backend/Dockerfile --tag registry.heroku.com/open-edx-backstage/web
+docker image build . -f packages/backend/Dockerfile --tag registry.heroku.com/openedx-backstage/web
 heroku login
 heroku container:login
-docker push registry.heroku.com/open-edx-backstage/web
-heroku container:release web -a open-edx-backstage
+docker push registry.heroku.com/openedx-backstage/web
+heroku container:release web -a openedx-backstage
 ```
 
 In case of any issues you can see the logs like so.
 
 ```sh
-heroku logs --tail -a open-edx-backstage
+heroku logs --tail -a openedx-backstage
 ```


### PR DESCRIPTION
I updated the name of the app in heroku to match the name in GitHub.
This results in some of the deployment instructions changing.

BREAKING CHANGE: The heroku app name is now `openedx-backstage` instead
of `open-edx-backstage`.
