### PR TITLE
docs: Check for updated base images during docker builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ authenticated.
 yarn install
 yarn tsc
 yarn build
-docker image build . -f packages/backend/Dockerfile --tag registry.heroku.com/openedx-backstage/web
+docker image build . -f packages/backend/Dockerfile --tag registry.heroku.com/openedx-backstage/web --pull
 heroku login
 heroku container:login
 docker push registry.heroku.com/openedx-backstage/web


### PR DESCRIPTION
We build a docker image as a part of deploying backstage.  While we're
doing that, we should check for updates to the image so we don't just
use the last one we pulled.  This will ensure that any updates to the
base image, including security updates, get pulled into our latest
release.
